### PR TITLE
S/improve testing and make --skip options available

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Provider Options:
                                                       [boolean] [default: false]
 
 Options:
-  --config      specify the project configuration in JSON               [string]
-  --no-install  add the new plugin but not install it [boolean] [default: false]
-  --no-git      do not initialize Git                 [boolean] [default: false]
+  --config        specify the project configuration in JSON             [string]
+  --skip-install  skip dependence installation        [boolean] [default: false]
+  --skip-git      do not initialize Git               [boolean] [default: false]
 ```
 
 You can create different types of Koop projects from templates:
@@ -80,10 +80,10 @@ Provider Options:
   --route-prefix  add a prefix to all of a registered routes            [string]
 
 Options:
-  --config       specify the plugin configuration in JSON               [string]
-  --add-to-root  add the given configuration to the app root configuration
+  --config        specify the plugin configuration in JSON              [string]
+  --add-to-root   add the given configuration to the app root configuration
                                                       [boolean] [default: false]
-  --no-install   add the new plugin but not install it[boolean] [default: false]
+  --skip-install  skip plugin installation            [boolean] [default: false]
 ```
 
 ### serve

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Once installed the `koop` command is available.
 koop <command>
 
 Commands:
-  koop new [type] [name]  create a new koop project
-  koop add [name]         add a new plugin to the current app
+  koop new <type> <name>  create a new koop project
+  koop add <type> <name>  add a new plugin to the current app
   koop test               run tests in the current project
   koop serve              run a koop server for the current project
 
@@ -43,7 +43,7 @@ Options:
 The `new` command creates a new Koop project from the template at the current location.
 
 ```
-koop new [type] [name]
+koop new <type> <name>
 
 Positionals:
   type  project type                       [string] [choices: "app", "provider"]
@@ -54,7 +54,9 @@ Provider Options:
                                                       [boolean] [default: false]
 
 Options:
-  --config   specify the project configuration in JSON                  [string]
+  --config      specify the project configuration in JSON               [string]
+  --no-install  add the new plugin but not install it [boolean] [default: false]
+  --no-git      do not initialize Git                 [boolean] [default: false]
 ```
 
 You can create different types of Koop projects from templates:
@@ -68,7 +70,7 @@ For more details on the project templates, please take a look at the Koop [speci
 The `add` command adds a Koop plugin to the current Koop app.
 
 ```
-koop add [type] [name]
+koop add <type> <name>
 
 Positionals:
   type  plugin type    [string] [choices: "output", "provider", "cache", "auth"]
@@ -81,6 +83,7 @@ Options:
   --config       specify the plugin configuration in JSON               [string]
   --add-to-root  add the given configuration to the app root configuration
                                                       [boolean] [default: false]
+  --no-install   add the new plugin but not install it[boolean] [default: false]
 ```
 
 ### serve

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,11 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "@turf/bbox-polygon": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz",
@@ -806,6 +811,32 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        }
+      }
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -1043,6 +1074,14 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1274,14 +1313,12 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "optional": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -1304,8 +1341,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1453,6 +1489,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -2132,6 +2173,16 @@
         "object-assign": "^4.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2282,6 +2333,15 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -2460,6 +2520,42 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "got": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
@@ -2521,11 +2617,24 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -2580,6 +2689,11 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -2765,8 +2879,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "optional": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "5.2.0",
@@ -2787,6 +2900,15 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
+      }
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
       }
     },
     "invert-kv": {
@@ -2955,6 +3077,11 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
     "is-observable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
@@ -2996,6 +3123,11 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3031,6 +3163,11 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3083,6 +3220,15 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
     "jest-get-type": {
       "version": "22.4.3",
       "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
@@ -3121,6 +3267,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -3201,6 +3352,14 @@
         "array-includes": "^3.0.3"
       }
     },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -3268,6 +3427,14 @@
       "integrity": "sha512-Z2nHtpQrF6TV6US8QigznVLl73yn3iMhrBEfDnm4PIuUFrigSElUt0arsD5caLSAPxLaZYfhjHuEtk4r8XdqsA==",
       "requires": {
         "featureserver": "^2.15.0"
+      }
+    },
+    "latest-version": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-4.0.0.tgz",
+      "integrity": "sha512-b4Myk7aQiQJvgssw2O8yITjELdqKRX4JQJUF1IUplgLaA8unv7s+UsAOwH6Q0/a09czSvlxEm306it2LBXrCzg==",
+      "requires": {
+        "package-json": "^5.0.0"
       }
     },
     "lcid": {
@@ -3548,6 +3715,11 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -3657,8 +3829,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "optional": true
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3766,6 +3937,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "moment": {
       "version": "2.22.2",
@@ -3890,6 +4067,16 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       }
     },
     "npm-path": {
@@ -4084,6 +4271,11 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -4121,10 +4313,29 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+    },
+    "package-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
+      "integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
+      "requires": {
+        "got": "^8.3.1",
+        "registry-auth-token": "^3.3.2",
+        "registry-url": "^3.1.0",
+        "semver": "^5.5.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -4407,6 +4618,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
     "pretty-format": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
@@ -4477,6 +4693,17 @@
         "ipaddr.js": "1.8.0"
       }
     },
+    "proxyquire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.0",
+        "resolve": "~1.8.1"
+      }
+    },
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
@@ -4500,6 +4727,16 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -4531,7 +4768,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -4542,8 +4778,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "optional": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -4666,6 +4901,23 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "^1.0.1"
+      }
+    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -4749,6 +5001,14 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -5115,6 +5375,14 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -5280,6 +5548,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-argv": {
       "version": "0.0.2",
@@ -5452,6 +5725,11 @@
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "tmp": {
       "version": "0.0.33",
@@ -5688,6 +5966,19 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "execa": "^1.0.0",
     "fs-extra": "^7.0.1",
     "koop": "^3.10.1",
+    "latest-version": "^4.0.0",
     "lodash": "^4.17.11",
     "node-fetch": "^2.3.0",
     "recast": "^0.16.2",
@@ -42,6 +43,7 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.0",
     "mocha": "^5.2.0",
+    "proxyquire": "^2.1.0",
     "standard": "^12.0.1"
   },
   "lint-staged": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,6 @@ module.exports = yargs
   .commandDir('commands')
   .middleware([parseConfig])
   .demandCommand()
-  .showHelpOnFail(true)
+  .showHelpOnFail(false)
   .help('help')
   .argv

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -25,8 +25,8 @@ function builder (yargs) {
       type: 'boolean',
       default: false
     })
-    .option('no-install', {
-      description: 'add the new plugin but not install it',
+    .option('skip-install', {
+      description: 'skip plugin installation',
       type: 'boolean',
       default: false
     })

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -25,6 +25,11 @@ function builder (yargs) {
       type: 'boolean',
       default: false
     })
+    .option('no-install', {
+      description: 'add the new plugin but not install it',
+      type: 'boolean',
+      default: false
+    })
 }
 
 async function handler (argv) {

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -21,12 +21,12 @@ function builder (yargs) {
       default: false,
       group: 'Provider Options:'
     })
-    .option('no-install', {
-      description: 'add the new plugin but not install it',
+    .option('skip-install', {
+      description: 'skip dependence installation',
       type: 'boolean',
       default: false
     })
-    .option('no-git', {
+    .option('skip-git', {
       description: 'do not initialize Git',
       type: 'boolean',
       default: false

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -21,6 +21,16 @@ function builder (yargs) {
       default: false,
       group: 'Provider Options:'
     })
+    .option('no-install', {
+      description: 'add the new plugin but not install it',
+      type: 'boolean',
+      default: false
+    })
+    .option('no-git', {
+      description: 'do not initialize Git',
+      type: 'boolean',
+      default: false
+    })
 }
 
 async function handler (argv) {

--- a/src/utils/add-config.js
+++ b/src/utils/add-config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs-extra')
+const writeJson = require('./write-formatted-json')
 
 module.exports = async (cwd, newConfig, options = {}) => {
   const configName = options.configName || 'default'
@@ -13,5 +14,5 @@ module.exports = async (cwd, newConfig, options = {}) => {
 
   config = Object.assign(config, newConfig)
 
-  return fs.writeJson(configPath, config)
+  return writeJson(configPath, config)
 }

--- a/src/utils/add-plugin.js
+++ b/src/utils/add-plugin.js
@@ -20,7 +20,7 @@ const astBuilders = recast.types.builders
  * @param  {string}  name         plugin name
  * @param  {Object}  [options={}] options
  * @param  {Object}  [options.config] plugin configuration
- * @param  {boolean} [options.noInstall]  add plugin withoult actual installation
+ * @param  {boolean} [options.skipInstall]  skip plugin installation
  * @param  {boolean} [options.addToRoot]  add plugin configuration to the app root configuration
  * @param  {boolean} [options.routePrefix]  URL prefix for register routes
  * @return {Promise}              a promise

--- a/src/utils/create-new-project.js
+++ b/src/utils/create-new-project.js
@@ -14,6 +14,8 @@ const scripts = require('./scripts')
  * @param  {Object}  [options={}] options
  * @param  {Object}  [options.config] configuration
  * @param  {boolean} [options.addServer]  add a server file for the provider project
+ * @param  {boolean} [options.noInstall]  add dependencies withoult actual installation
+ * @param  {boolean} [options.noGit]  not to initialize git
  * @return {Promise}              a promise
  */
 module.exports = async (cwd, type, name, options = {}) => {
@@ -25,7 +27,7 @@ module.exports = async (cwd, type, name, options = {}) => {
 
   log('\u2713 created project folder', 'info', options)
 
-  if (!options.skipGit) {
+  if (!options.noGit) {
     await setupGit(projectPath)
     log('\u2713 initialized Git', 'info', options)
   }
@@ -42,7 +44,7 @@ module.exports = async (cwd, type, name, options = {}) => {
     log(`\u2713 added ${type} configuration`, 'info', options)
   }
 
-  if (!options.skipInstall) {
+  if (!options.noGit) {
     const script = scripts.NPM_INSTALL
     // install dependencies
     await execa.shell(script, { cwd: projectPath })

--- a/src/utils/create-new-project.js
+++ b/src/utils/create-new-project.js
@@ -5,6 +5,7 @@ const addConfig = require('./add-config')
 const setupGit = require('./setup-git')
 const log = require('./log')
 const scripts = require('./scripts')
+const writeJson = require('./write-formatted-json')
 
 /**
  * Creat a new koop project.
@@ -27,7 +28,7 @@ module.exports = async (cwd, type, name, options = {}) => {
 
   log('\u2713 created project folder', 'info', options)
 
-  if (!options.noGit) {
+  if (!options.skipGit) {
     await setupGit(projectPath)
     log('\u2713 initialized Git', 'info', options)
   }
@@ -44,7 +45,7 @@ module.exports = async (cwd, type, name, options = {}) => {
     log(`\u2713 added ${type} configuration`, 'info', options)
   }
 
-  if (!options.noGit) {
+  if (!options.skipInstall) {
     const script = scripts.NPM_INSTALL
     // install dependencies
     await execa.shell(script, { cwd: projectPath })
@@ -84,7 +85,7 @@ async function customizePackage (projectPath, type, name, options = {}) {
     packageConfig.dependencies.koop = koopConfig.koopCompatibility
   }
 
-  return fs.writeJson(packagePath, packageConfig)
+  return writeJson(packagePath, packageConfig)
 }
 
 async function customizeApp (projectPath, type, name) {
@@ -98,7 +99,7 @@ async function customizeProvider (projectPath, type, name, options = {}) {
   config[name] = config['koop-cli-new-provider']
   delete config['koop-cli-new-provider']
 
-  await fs.writeJson(configPath, config)
+  await writeJson(configPath, config)
 
   // add a server file to the koop provider project so the user does not have to
   // publish the provider and use it without koop-cli

--- a/src/utils/create-new-project.js
+++ b/src/utils/create-new-project.js
@@ -15,8 +15,8 @@ const writeJson = require('./write-formatted-json')
  * @param  {Object}  [options={}] options
  * @param  {Object}  [options.config] configuration
  * @param  {boolean} [options.addServer]  add a server file for the provider project
- * @param  {boolean} [options.noInstall]  add dependencies withoult actual installation
- * @param  {boolean} [options.noGit]  not to initialize git
+ * @param  {boolean} [options.skipInstall]  skip dependency installation
+ * @param  {boolean} [options.skipGit]  skip Git initialization
  * @return {Promise}              a promise
  */
 module.exports = async (cwd, type, name, options = {}) => {

--- a/src/utils/write-formatted-json.js
+++ b/src/utils/write-formatted-json.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const fs = require('fs-extra')
 
 /**
@@ -9,6 +10,6 @@ const fs = require('fs-extra')
 module.exports = async (path, data) => {
   return fs.writeJson(path, data, {
     spaces: 2,
-    EOL: '\n'
+    EOL: os.EOL
   })
 }

--- a/src/utils/write-formatted-json.js
+++ b/src/utils/write-formatted-json.js
@@ -1,0 +1,14 @@
+const fs = require('fs-extra')
+
+/**
+ * Write formatted JSON into a file.
+ * @param  {string}  path file path
+ * @param  {Object}  data JSON data
+ * @return {Promise}      a promise
+ */
+module.exports = async (path, data) => {
+  return fs.writeJson(path, data, {
+    spaces: 2,
+    EOL: '\n'
+  })
+}

--- a/test/utils/add-plugin.test.js
+++ b/test/utils/add-plugin.test.js
@@ -18,7 +18,9 @@ const defaultOptions = {
 
 let appName, appPath
 
-describe('utils/add-plugin', () => {
+describe('utils/add-plugin', function () {
+  this.timeout(5000)
+
   beforeEach(async () => {
     appName = `add-command-test-${Date.now()}`
     appPath = path.join(temp, appName)

--- a/test/utils/add-plugin.test.js
+++ b/test/utils/add-plugin.test.js
@@ -7,16 +7,13 @@ const os = require('os')
 const proxyquire = require('proxyquire')
 const createNewProject = require('../../src/utils/create-new-project')
 
-const addPlugin = proxyquire('../../src/utils/add-plugin', {
-  'latest-version': async () => '1.0.0'
-})
-
+const modulePath = '../../src/utils/add-plugin'
 const expect = chai.expect
 const temp = os.tmpdir()
 
 const defaultOptions = {
-  noGit: true,
-  noInstall: true,
+  skipGit: true,
+  skipInstall: true,
   quiet: true
 }
 
@@ -30,6 +27,9 @@ describe('utils/add-plugin', () => {
   })
 
   it('should add a plugin to an app project', async () => {
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '1.0.0'
+    })
     await addPlugin(appPath, 'provider', 'test-provider', defaultOptions)
 
     const plugins = await fs.readFile(path.join(appPath, 'src', 'plugins.js'), 'utf-8')
@@ -48,6 +48,9 @@ describe('utils/add-plugin', () => {
   })
 
   it('should add a plugin published as a scoped module', async () => {
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '1.0.0'
+    })
     await addPlugin(appPath, 'provider', '@koop/test-provider', defaultOptions)
 
     const plugins = await fs.readFile(path.join(appPath, 'src', 'plugins.js'), 'utf-8')
@@ -60,10 +63,16 @@ describe('utils/add-plugin', () => {
       'module.exports = [...outputs, ...plugins];'
     ].join(os.EOL)
     expect(plugins).to.equal(expected)
+
+    const packageInfo = await fs.readJson(path.join(appPath, 'package.json'))
+    expect(packageInfo.dependencies['@koop/test-provider']).to.equal('^1.0.0')
   })
 
   it('should add a plugin published with a version number', async () => {
-    await addPlugin(appPath, 'provider', '@koop/test-provider@^3.2.0', defaultOptions)
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '3.2.1'
+    })
+    await addPlugin(appPath, 'provider', '@koop/test-provider@3.2.0', defaultOptions)
 
     const plugins = await fs.readFile(path.join(appPath, 'src', 'plugins.js'), 'utf-8')
     const expected = [
@@ -75,9 +84,15 @@ describe('utils/add-plugin', () => {
       'module.exports = [...outputs, ...plugins];'
     ].join(os.EOL)
     expect(plugins).to.equal(expected)
+
+    const packageInfo = await fs.readJson(path.join(appPath, 'package.json'))
+    expect(packageInfo.dependencies['@koop/test-provider']).to.equal('^3.2.1')
   })
 
   it('should add plugin config if provided', async () => {
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '3.2.1'
+    })
     await addPlugin(
       appPath,
       'provider',
@@ -95,6 +110,9 @@ describe('utils/add-plugin', () => {
   })
 
   it('should append the plugin config to the app config if specified', async () => {
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '3.2.1'
+    })
     await addPlugin(
       appPath,
       'provider',
@@ -111,6 +129,9 @@ describe('utils/add-plugin', () => {
   })
 
   it('should add the output plugin to the output list in the project', async () => {
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '3.2.1'
+    })
     await addPlugin(appPath, 'output', '@koop/output-tile', defaultOptions)
 
     const plugins = await fs.readFile(path.join(appPath, 'src', 'plugins.js'), 'utf-8')
@@ -127,6 +148,9 @@ describe('utils/add-plugin', () => {
   })
 
   it('should add the plugin options to the plugin list', async () => {
+    const addPlugin = proxyquire(modulePath, {
+      'latest-version': async () => '3.2.1'
+    })
     await addPlugin(
       appPath,
       'provider',

--- a/test/utils/add-plugin.test.js
+++ b/test/utils/add-plugin.test.js
@@ -5,7 +5,6 @@ const path = require('path')
 const fs = require('fs-extra')
 const os = require('os')
 const proxyquire = require('proxyquire')
-const createNewProject = require('../../src/utils/create-new-project')
 
 const modulePath = '../../src/utils/add-plugin'
 const expect = chai.expect
@@ -177,3 +176,13 @@ describe('utils/add-plugin', () => {
     expect(plugins).to.equal(expected)
   })
 })
+
+async function createNewProject (cwd, type, name) {
+  const templatePath = path.resolve(__dirname, '../../src/templates/app/project')
+  const projectPath = path.join(cwd, name)
+
+  // just copy the app template and no need to use the formal project creator
+  // (skip some file I/O)
+  await fs.ensureDir(projectPath)
+  await fs.copy(templatePath, projectPath)
+}

--- a/test/utils/add-plugin.test.js
+++ b/test/utils/add-plugin.test.js
@@ -4,15 +4,19 @@ const chai = require('chai')
 const path = require('path')
 const fs = require('fs-extra')
 const os = require('os')
+const proxyquire = require('proxyquire')
 const createNewProject = require('../../src/utils/create-new-project')
-const addPlugin = require('../../src/utils/add-plugin')
+
+const addPlugin = proxyquire('../../src/utils/add-plugin', {
+  'latest-version': async () => '1.0.0'
+})
 
 const expect = chai.expect
 const temp = os.tmpdir()
 
 const defaultOptions = {
-  skipGit: true,
-  skipInstall: true,
+  noGit: true,
+  noInstall: true,
   quiet: true
 }
 
@@ -38,6 +42,9 @@ describe('utils/add-plugin', () => {
       'module.exports = [...outputs, ...plugins];'
     ].join(os.EOL)
     expect(plugins).to.equal(expected)
+
+    const packageInfo = await fs.readJson(path.join(appPath, 'package.json'))
+    expect(packageInfo.dependencies['test-provider']).to.equal('^1.0.0')
   })
 
   it('should add a plugin published as a scoped module', async () => {

--- a/test/utils/create-new-project.test.js
+++ b/test/utils/create-new-project.test.js
@@ -10,8 +10,8 @@ const expect = chai.expect
 const temp = os.tmpdir()
 
 const defaultOptions = {
-  skipGit: true,
-  skipInstall: true,
+  noGit: true,
+  noInstall: true,
   quiet: true
 }
 

--- a/test/utils/create-new-project.test.js
+++ b/test/utils/create-new-project.test.js
@@ -10,8 +10,8 @@ const expect = chai.expect
 const temp = os.tmpdir()
 
 const defaultOptions = {
-  noGit: true,
-  noInstall: true,
+  skipGit: true,
+  skipInstall: true,
   quiet: true
 }
 

--- a/test/utils/setup-git.test.js
+++ b/test/utils/setup-git.test.js
@@ -2,9 +2,15 @@
 
 const chai = require('chai')
 const fs = require('fs-extra')
+const proxyquire = require('proxyquire')
 const path = require('path')
 const os = require('os')
-const setupGit = require('../../src/utils/setup-git')
+
+const setupGit = proxyquire('../../src/utils/setup-git', {
+  'node-fetch': async () => ({
+    text: async () => 'test'
+  })
+})
 
 const expect = chai.expect
 const temp = os.tmpdir()


### PR DESCRIPTION
This PR will
* improve the testing by mocking all external requests
* make `--skip-git` and `--skip-install` available to the user. If used, the dependency/plugin will be added to the package.json but not actually installed. This is useful in the use case when we just want to quickly create a project but not want to use it right away.