### PR TITLE
B/fix package installation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unpublished
+
+### Fixed
+
+* `add` command doesn't install the correct plugin name
+
 ## 0.3.2 - 2019-04-19
 
 ### Fixed
 
-* Node.js `add()` API is broken (#27) 
+* Node.js `add()` API is broken (#27)
 
 ## 0.3.1 - 2019-04-18
 

--- a/src/utils/add-plugin/add-npm-plugin.js
+++ b/src/utils/add-plugin/add-npm-plugin.js
@@ -31,6 +31,7 @@ module.exports = async function addNpmPlugin (cwd, type, plugin, options = {}) {
     await writeJson(packageInfoPath, packageInfo)
   } else {
     const script = scripts.NPM_INSTALL
-    await execa.shell(`${script} ${plugin.versionedFullName}`, { cwd })
+    const moduleName = plugin.versionedFullName || plugin.fullName
+    await execa.shell(`${script} ${moduleName}`, { cwd })
   }
 }

--- a/test/utils/add-plugin/add-npm-plugin.test.js
+++ b/test/utils/add-plugin/add-npm-plugin.test.js
@@ -109,5 +109,56 @@ describe('utils/add-plugin', function () {
       const packageInfo = await fs.readJson(path.join(appPath, 'package.json'))
       expect(packageInfo.dependencies['@koop/test-provider']).to.equal('^3.2.1')
     })
+
+    it('should install a npm plugin with the full module name', async () => {
+      const addNpmPlugin = proxyquire(addNpmPluginModulePath, {
+        execa: {
+          shell (script, options) {
+            expect(script).to.equal('npm install --quiet @koopjs/test-provider')
+            expect(options.cwd).to.equal(appPath)
+          }
+        }
+      })
+      const addPlugin = proxyquire(modulePath, {
+        './add-npm-plugin': addNpmPlugin
+      })
+      await addPlugin(appPath, 'provider', '@koopjs/test-provider', {
+        quiet: true
+      })
+    })
+
+    it('should install a npm plugin with the full module name with version', async () => {
+      const addNpmPlugin = proxyquire(addNpmPluginModulePath, {
+        execa: {
+          shell (script, options) {
+            expect(script).to.equal('npm install --quiet @koopjs/test-provider@^3.0.0')
+            expect(options.cwd).to.equal(appPath)
+          }
+        }
+      })
+      const addPlugin = proxyquire(modulePath, {
+        './add-npm-plugin': addNpmPlugin
+      })
+      await addPlugin(appPath, 'provider', '@koopjs/test-provider@^3.0.0', {
+        quiet: true
+      })
+    })
+
+    it('should install a npm plugin with the full module name with tag', async () => {
+      const addNpmPlugin = proxyquire(addNpmPluginModulePath, {
+        execa: {
+          shell (script, options) {
+            expect(script).to.equal('npm install --quiet @koopjs/test-provider@latest')
+            expect(options.cwd).to.equal(appPath)
+          }
+        }
+      })
+      const addPlugin = proxyquire(modulePath, {
+        './add-npm-plugin': addNpmPlugin
+      })
+      await addPlugin(appPath, 'provider', '@koopjs/test-provider@latest', {
+        quiet: true
+      })
+    })
   })
 })


### PR DESCRIPTION
The `add` command uses a wrong key for the package name during the installation (#28).