### PR TITLE
F/allow to start a dev server with a local Koop CLI in the Koop project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+* allow to start a dev server with the local Koop CLI in a Koop project
+
 ## 0.3.3 - 2019-05-16
 
 ### Fixed
 
-* `add` command doesn't install the correct package name
+* `add` command doesn't install the correct package name (#29)
 
 ## 0.3.2 - 2019-04-19
 

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -20,31 +20,22 @@ async function handler (argv = {}) {
   const configPath = path.join(process.cwd(), 'koop.json')
   const koopConfig = await fs.readJson(configPath)
 
-  createServer[koopConfig.type](argv.port)
+  await createServer[koopConfig.type](argv.port)
 }
 
-function serveApp () {
-  const packageInfo = fs.readJsonSync(path.join(process.cwd(), 'package.json'))
-  const command = packageInfo.scripts.start
-    ? 'npm run start'
-    : `node ${packageInfo.main}`
-
-  exec(command)
+async function serveApp () {
+  const packageInfo = await fs.readJson(path.join(process.cwd(), 'package.json'))
+  exec(`node ${packageInfo.main}`)
 }
 
-function serveProvider (port) {
-  const packageInfo = fs.readJsonSync(path.join(process.cwd(), 'package.json'))
+async function serveProvider (port) {
+  const packageInfo = await fs.readJson(path.join(process.cwd(), 'package.json'))
+  const Koop = require('koop')
+  const koop = new Koop()
 
-  if (packageInfo.scripts.start) {
-    exec('npm run start')
-  } else {
-    const Koop = require('koop')
-    const koop = new Koop()
-
-    const provider = require(path.join(process.cwd(), packageInfo.main))
-    koop.register(provider)
-    koop.server.listen(port || 8080)
-  }
+  const provider = require(path.join(process.cwd(), packageInfo.main))
+  koop.register(provider)
+  koop.server.listen(port || 8080)
 }
 
 module.exports = {

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -35,7 +35,10 @@ async function serveProvider (port) {
 
   const provider = require(path.join(process.cwd(), packageInfo.main))
   koop.register(provider)
-  koop.server.listen(port || 8080)
+  const serverPort = port || 8080
+  koop.server.listen(serverPort, () => {
+    console.log(`Server listening at http://localhost:${serverPort}`)
+  })
 }
 
 module.exports = {

--- a/src/template/project/README.md
+++ b/src/template/project/README.md
@@ -8,6 +8,22 @@ See the [specification](https://koopjs.github.io/docs/usage/koop-core) for more 
 
 This project is configured with [config](https://www.npmjs.com/package/config). As a community practice, it is recommanded to namespace the configuration for plugins in order to avoid any potential key conflict.
 
-## Testing
+## Development
 
-This project uses [mocah](https://www.npmjs.com/package/mocha) as the testing framework. All test files in the `test` directory should have the extension `.test.js` and the `npm test` command will be able to run on them.
+### Testing
+
+This project uses [mocah](https://www.npmjs.com/package/mocha) as the testing framework and [chaijs](https://www.chaijs.com/) as the assertion library. All test files in the `test` directory should have the special extension `.test.js`, which will be executed by the command:
+
+```
+$ npm test
+```
+
+### Dev Server
+
+This project by default uses the [Koop CLI](https://github.com/koopjs/koop-cli) to set up the dev server. It can be invoded with
+
+```
+$ npm start
+```
+
+For more details, check the [Koop CLI documentation](https://github.com/koopjs/koop-cli/blob/master/README.md).

--- a/src/template/project/README.md
+++ b/src/template/project/README.md
@@ -20,10 +20,12 @@ $ npm test
 
 ### Dev Server
 
-This project by default uses the [Koop CLI](https://github.com/koopjs/koop-cli) to set up the dev server. It can be invoded with
+This project by default uses the [Koop CLI](https://github.com/koopjs/koop-cli) to set up the dev server. It can be invoded via
 
 ```
 $ npm start
 ```
+
+The server will be running at `http://localhost:8080` or at the port specified at the configuration.
 
 For more details, check the [Koop CLI documentation](https://github.com/koopjs/koop-cli/blob/master/README.md).

--- a/src/template/project/package.json
+++ b/src/template/project/package.json
@@ -4,12 +4,14 @@
   "description": "A project template for Koop",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha test/*.test.js"
+    "test": "mocha test/*.test.js",
+    "start": "koop serve"
   },
   "dependencies": {
     "config": "^3.1.0"
   },
   "devDependencies": {
+    "@koopjs/cli": "^0.3.3",
     "chai": "^4.2.0",
     "mocha": "^6.1.4"
   },

--- a/src/template/project/package.json
+++ b/src/template/project/package.json
@@ -4,7 +4,7 @@
   "description": "A project template for Koop",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha test/*.test.js",
+    "test": "mocha 'test/*.test.js'",
     "start": "koop serve"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, the plugin developer can only use a global `koop start` command to start a dev server if the Koop plugin is created by the CLI. This PR modifies the command so that the dev server can be started with a local CLI. It should improve project portability.

The `koop start` command no longer executes the `npm start` script in the package.json to avoid recursive calls.