### PR TITLE
S/use koop.json to configure provider properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unrelease
 ### Changed
 * Support adding a plugin that already exists locally
+* Use `koop.json` to configure provider properties
 
 ## 0.6.3 - 2020-08-28
 ### Change

--- a/src/template/components/provider/koop.json
+++ b/src/template/components/provider/koop.json
@@ -1,3 +1,8 @@
 {
-  "type": "provider"
+  "type": "provider",
+  "name": "koop-cli-new-provider",
+  "allowedParams": {
+    "host": true,
+    "id": false
+  }
 }

--- a/src/template/components/provider/src/index.js
+++ b/src/template/components/provider/src/index.js
@@ -1,12 +1,13 @@
 
 const packageInfo = require('../package.json')
+const koopConfig = require('../koop.json')
 
 const provider = {
   type: 'provider',
-  name: 'koop-cli-new-provider',
   version: packageInfo.version,
-  hosts: true,
-  disableIdParam: true,
+  name: koopConfig.name,
+  hosts: koopConfig.allowedParams.host,
+  disableIdParam: !koopConfig.allowedParams.id,
   Model: require('./model')
 }
 

--- a/src/template/project/README.md
+++ b/src/template/project/README.md
@@ -6,7 +6,13 @@ See the [specification](https://koopjs.github.io/docs/usage/koop-core) for more 
 
 ## Configuration
 
-This project is configured with [config](https://www.npmjs.com/package/config). As a community practice, it is recommended to namespace the configuration for plugins in order to avoid any potential key conflict.
+### App Configuration
+
+The Koop application is configured with the [config](https://www.npmjs.com/package/config) package. By default the configurations are stored as JSON files in the `config` folder. It is recommended to namespace the configuration for plugins in order to avoid any potential key conflict.
+
+### Koop Configuration
+
+The Koop project configuration `koop.json` is the configuration for the app/plugin code. It is part of the code and used to store internal properties of the app/plugin. It should not be changed with the deployment.
 
 ## Development
 

--- a/src/template/project/koop.json
+++ b/src/template/project/koop.json
@@ -1,5 +1,4 @@
 {
-  "version": 1,
-  "koopCompatibility": ">=3",
+  "version": "1",
   "npmClient": "npm"
 }

--- a/test/utils/create-new-project/index.test.js
+++ b/test/utils/create-new-project/index.test.js
@@ -48,6 +48,8 @@ describe('utils/create-new-project', () => {
 
     const koopConfig = await fs.readJson(path.join(appPath, 'koop.json'))
     expect(koopConfig.type).to.equal('provider')
+    expect(koopConfig.name).to.be.a('string')
+    expect(koopConfig.allowedParams).to.be.an('object')
 
     expect(await fs.pathExists(path.join(appPath, 'src/index.js'))).to.equal(true)
     expect(await fs.pathExists(path.join(appPath, 'src/model.js'))).to.equal(true)


### PR DESCRIPTION
Move some provider configuration values into `koop.json` so make it easier to be modified by the user