### PR TITLE
F/add plugin list in the koop.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unrelease
+### Added
+* Plugin list in the `koop.json`
+
 ### Changed
 * Support adding a plugin that already exists locally
 * Use `koop.json` to configure provider properties

--- a/src/template/components/app/koop.json
+++ b/src/template/components/app/koop.json
@@ -1,3 +1,4 @@
 {
-  "type": "app"
+  "type": "app",
+  "plugins": []
 }

--- a/src/template/components/app/test/koop.test.js
+++ b/src/template/components/app/test/koop.test.js
@@ -1,0 +1,14 @@
+/* eslint-env mocha */
+
+const fs = require('fs')
+const chai = require('chai')
+const path = require('path')
+const expect = chai.expect
+
+describe('koop.json', function () {
+  const koopConfig = JSON.parse(fs.readFileSync(path.join(__dirname, '../koop.json'), 'utf-8'))
+
+  it('should have a plugin list', () => {
+    expect(koopConfig.plugins).to.be.an('array')
+  })
+})

--- a/src/utils/add-plugin/index.js
+++ b/src/utils/add-plugin/index.js
@@ -5,6 +5,7 @@ const addNpmPlugin = require('./add-npm-plugin')
 const registerPlugin = require('./register-plugin')
 const updateProjectConfig = require('../update-project-config')
 const addPluginInitializer = require('./add-plugin-initializer')
+const updatePluginList = require('./update-koop-plugin-list')
 const log = require('../log')
 const parsePluginName = require('./parse-plugin-name')
 const parsePluginPath = require('./parse-plugin-path')
@@ -48,8 +49,10 @@ module.exports = async (cwd, type, nameOrPath, options = {}) => {
    * Add plugin config
    */
 
-  await updateProjectConfig(cwd, type, plugin.fullModuleName, options.config)
-  log('\u2713 added plugin configuration', 'info', options)
+  if (options.config) {
+    await updateProjectConfig(cwd, type, plugin.fullModuleName, options.config)
+    log('\u2713 added plugin configuration', 'info', options)
+  }
 
   /**
    * Add the initializer.js for the plugin
@@ -62,6 +65,12 @@ module.exports = async (cwd, type, nameOrPath, options = {}) => {
 
   await registerPlugin(cwd, type, plugin, options)
   log(`\u2713 registered ${plugin.moduleName}`, 'info', options)
+
+  /**
+   * Update plugin list
+   */
+
+  await updatePluginList(cwd, type, plugin, options)
 
   /**
    * Done

--- a/src/utils/add-plugin/update-koop-plugin-list.js
+++ b/src/utils/add-plugin/update-koop-plugin-list.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const fs = require('fs-extra')
+const writeJSON = require('../write-formatted-json')
+
+module.exports = async (cwd, type, plugin, options = {}) => {
+  const koopConfigPath = path.join(cwd, 'koop.json')
+  const koopConfig = await fs.readJSON(koopConfigPath)
+
+  if (!koopConfig.plugins) {
+    koopConfig.plugins = []
+  }
+
+  koopConfig.plugins.push({
+    type,
+    name: plugin.fullModuleName,
+    srcPath: plugin.srcPath,
+    local: !!options.local
+  })
+
+  await writeJSON(koopConfigPath, koopConfig)
+}

--- a/src/utils/update-project-config.js
+++ b/src/utils/update-project-config.js
@@ -1,9 +1,17 @@
 const path = require('path')
 const fs = require('fs-extra')
+const _ = require('lodash')
 const writeJson = require('./write-formatted-json')
 
 module.exports = async (cwd, type, name, newConfig = {}) => {
   const configPath = path.join(cwd, 'config/default.json')
+
+  // do nothing if
+  // 1. the app is not using config/defult.json for configuration
+  // 2. the new config is empty
+  if (!(await fs.pathExists(configPath)) || _.isEmpty(newConfig)) {
+    return
+  }
 
   let config = {}
 

--- a/test/utils/add-plugin/add-local-plugin.test.js
+++ b/test/utils/add-plugin/add-local-plugin.test.js
@@ -169,5 +169,18 @@ describe('utils/add-plugin', function () {
       expect(await fs.pathExists(path.join(testPath, 'routes.test.js'))).to.equal(true)
       expect(await fs.pathExists(path.join(testPath, 'request-handlers/serve.test.js'))).to.equal(true)
     })
+
+    it('should update the plugin list in koop.json', async () => {
+      const addPlugin = require(modulePath)
+      await addPlugin(appPath, 'provider', 'plugins/test-provider', defaultOptions)
+
+      const koopConfig = await fs.readJson(path.join(appPath, 'koop.json'))
+      const pluginInfo = koopConfig.plugins[0]
+
+      expect(pluginInfo.name).to.equal('test-provider')
+      expect(pluginInfo.type).to.equal('provider')
+      expect(pluginInfo.srcPath).to.equal('plugins/test-provider')
+      expect(pluginInfo.local).to.equal(true)
+    })
   })
 })

--- a/test/utils/add-plugin/add-npm-plugin.test.js
+++ b/test/utils/add-plugin/add-npm-plugin.test.js
@@ -174,5 +174,23 @@ describe('utils/add-plugin', function () {
         npmClient: 'yarn'
       })
     })
+
+    it('should update the plugin list in koop.json', async () => {
+      const addNpmPlugin = proxyquire(addNpmPluginModulePath, {
+        'latest-version': async () => '1.0.0'
+      })
+      const addPlugin = proxyquire(modulePath, {
+        './add-npm-plugin': addNpmPlugin
+      })
+      await addPlugin(appPath, 'provider', 'test-provider', defaultOptions)
+
+      const koopConfig = await fs.readJson(path.join(appPath, 'koop.json'))
+      const pluginInfo = koopConfig.plugins[0]
+
+      expect(pluginInfo.name).to.equal('test-provider')
+      expect(pluginInfo.type).to.equal('provider')
+      expect(pluginInfo.srcPath).to.equal('test-provider')
+      expect(pluginInfo.local).to.equal(false)
+    })
   })
 })

--- a/test/utils/create-new-project/index.test.js
+++ b/test/utils/create-new-project/index.test.js
@@ -32,6 +32,7 @@ describe('utils/create-new-project', () => {
 
     const koopConfig = await fs.readJson(path.join(appPath, 'koop.json'))
     expect(koopConfig.type).to.equal('app')
+    expect(koopConfig.plugins).to.be.an('Array')
 
     expect(await fs.pathExists(path.join(appPath, 'src/index.js'))).to.equal(true)
     expect(await fs.pathExists(path.join(appPath, 'src/routes.js'))).to.equal(true)


### PR DESCRIPTION
This PR adds the `plugins` array in the `koop.json` file and updates the `add` command to maintain it. This list will be used by the upcoming `list` command and `remove` command.