### PR TITLE
F/validate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Plugin list in the `koop.json`
 * New `remove` command and API
 * New `list` command and API
+* New `Validate` command and API
 
 ### Changed
 * Support adding a plugin that already exists locally

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Commands:
   koop list [type]        list plugins added to the current app
   koop test               run tests in the current project
   koop serve [path]       run a Koop server for the current project
+  koop validate           validte the current plugin
 
 Options:
   --quiet    supress all console messages except errors

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -15,6 +15,8 @@ Positionals:
 The command will list plugins in a table in the terminal, for example
 
 ```
+2 plugins are found.
+
 #  Name           Type      Is local plugin?
 -  -------------  --------  ----------------
 1  test-output    output    true

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -13,14 +13,14 @@ validte the current plugin exports
 The command will print the result of validation. If the validation passes,
 
 ```
-The plugin is valid
+The plugin is valid.
 ```
 
 or if there is any error,
 
 
 ```
-The plugin is not valid
+The plugin is not valid.
 
 #  Property       Error
 -  -------------  -----------------------------------

--- a/docs/commands/validate.md
+++ b/docs/commands/validate.md
@@ -1,0 +1,57 @@
+# validate
+
+The `validate` command validates the exports of a Koop plugin library based on the specification. If the plugin library doesn't export necessary or valid properties, this command will return a list of errors.
+
+Currently support plugin types: provider
+
+```
+koop validate
+
+validte the current plugin exports
+```
+
+The command will print the result of validation. If the validation passes,
+
+```
+The plugin is valid
+```
+
+or if there is any error,
+
+
+```
+The plugin is not valid
+
+#  Property       Error
+-  -------------  -----------------------------------
+1  type           the value is empty
+2  Model          the "getData" function is not added
+```
+
+## API
+
+Validate the current plugin
+
+* `cwd`: Koop app directory
+
+Return a promise.
+
+``` javascript
+const cli = require('@koopjs/cli')
+
+cli
+  .validate('/Documents/my-provider')
+  .then((result) => {
+  /**
+   * the "result" is an object
+   * {
+   *   // a boolean value indicating whether the validation is passed
+   *   valid: false,
+   *   errors: [
+   *     { property: "type", message: "the message is empty" }
+   *   ]
+   * }
+   *
+   */
+  })
+```

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -18,10 +18,10 @@ async function handler (argv) {
 
   if (plugins.length === 0) {
     // TODO replace it with new logger
-    console.log('No plugin is found')
+    console.log('No plugin is found.')
   } else {
     // TODO replace it with new logger
-    console.log(`${plugins.length} plugins are found\n`)
+    console.log(`${plugins.length} plugins are found.\n`)
 
     const table = new Table()
 

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -17,22 +17,26 @@ async function handler (argv) {
   const plugins = await listPlugins(cwd, type, argv)
 
   if (plugins.length === 0) {
-    return
+    // TODO replace it with new logger
+    console.log('No plugin is found')
+  } else {
+    // TODO replace it with new logger
+    console.log(`${plugins.length} plugins are found\n`)
+
+    const table = new Table()
+
+    _
+      .sortBy(plugins, 'type')
+      .forEach((plugin, index) => {
+        table.cell('#', index + 1)
+        table.cell('Name', plugin.name)
+        table.cell('Type', plugin.type)
+        table.cell('Is local plugin?', plugin.local)
+        table.newRow()
+      })
+
+    console.log(table.toString())
   }
-
-  const table = new Table()
-
-  _
-    .sortBy(plugins, 'type')
-    .forEach((plugin, index) => {
-      table.cell('#', index + 1)
-      table.cell('Name', plugin.name)
-      table.cell('Type', plugin.type)
-      table.cell('Is local plugin?', plugin.local)
-      table.newRow()
-    })
-
-  console.log(table.toString())
 }
 
 module.exports = {

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -1,0 +1,35 @@
+const Table = require('easy-table')
+const _ = require('lodash')
+const validatePlugin = require('../utils/validate-plugin')
+
+async function handler (argv) {
+  const cwd = process.cwd()
+  const result = await validatePlugin(cwd, argv)
+
+  if (result.valid) {
+    // TODO use a new logger
+    console.log('The plugin is valid')
+  } else {
+    // TODO use a new logger
+    console.log('The plugin is not valid\n')
+
+    const table = new Table()
+
+    _
+      .sortBy(result.errors, 'property')
+      .forEach((error, index) => {
+        table.cell('#', index + 1)
+        table.cell('Property', error.property)
+        table.cell('Error', error.message)
+        table.newRow()
+      })
+
+    console.log(table.toString())
+  }
+}
+
+module.exports = {
+  command: 'validate',
+  description: 'validte the current plugin exports',
+  handler
+}

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -8,10 +8,10 @@ async function handler (argv) {
 
   if (result.valid) {
     // TODO use a new logger
-    console.log('The plugin is valid')
+    console.log('The plugin is valid.')
   } else {
     // TODO use a new logger
-    console.log('The plugin is not valid\n')
+    console.log('The plugin is not valid.\n')
 
     const table = new Table()
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const createNewProject = require('./utils/create-new-project')
 const addPlugin = require('./utils/add-plugin')
 const removePlugin = require('./utils/remove-plugin')
 const listPlugins = require('./utils/list-plugins')
+const validatePlugin = require('./utils/validate-plugin')
 
 // set "quiet" option to true to avoid additional log messages
 module.exports = {
@@ -15,5 +16,6 @@ module.exports = {
   remove: (cwd, name, options) => {
     return removePlugin(cwd, name, _.assign({ quiet: true }, options))
   },
-  list: listPlugins
+  list: listPlugins,
+  validate: validatePlugin
 }

--- a/src/utils/validate-plugin/create-validation-error.js
+++ b/src/utils/validate-plugin/create-validation-error.js
@@ -1,0 +1,3 @@
+module.exports = (property, message) => {
+  return { property, message }
+}

--- a/src/utils/validate-plugin/index.js
+++ b/src/utils/validate-plugin/index.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const fs = require('fs-extra')
+const validateProvider = require('./validate-provider')
+
+module.exports = async (cwd, options) => {
+  const allowedTypes = ['provider']
+  const koopConfig = await fs.readJson(path.join(cwd, 'koop.json'))
+
+  // NOTE validation only works for some plugin types now
+  if (!allowedTypes.includes(koopConfig.type)) {
+    throw new Error(`The project type ${koopConfig.type} is not supported`)
+  }
+
+  let result
+
+  if (koopConfig.type === 'provider') {
+    result = await validateProvider(cwd, options)
+  }
+
+  return result
+}

--- a/src/utils/validate-plugin/load-plugin.js
+++ b/src/utils/validate-plugin/load-plugin.js
@@ -1,0 +1,10 @@
+const path = require('path')
+const fs = require('fs-extra')
+
+module.exports = async (cwd) => {
+  const packageInfo = await fs.readJson(path.join(cwd, 'package.json'))
+  const mainEntry = packageInfo.main
+  const plugin = require(path.join(cwd, mainEntry))
+  const pluginInstance = typeof plugin === 'function' ? plugin() : plugin
+  return pluginInstance
+}

--- a/src/utils/validate-plugin/validate-provider.js
+++ b/src/utils/validate-plugin/validate-provider.js
@@ -1,0 +1,39 @@
+const createError = require('./create-validation-error')
+const loadPlugin = require('./load-plugin')
+
+module.exports = async (cwd) => {
+  try {
+    const pluginInstance = await loadPlugin(cwd)
+    return isValidProvider(pluginInstance)
+  } catch (error) {
+    // TODO replace this with a new logger
+    console.error('Unable to load and validate the provider')
+    throw error
+  }
+}
+
+function isValidProvider (plugin) {
+  const errors = []
+
+  if (plugin.type !== 'provider') {
+    errors.push(createError('type', 'the value is not "provider"'))
+  }
+
+  if (!plugin.name) {
+    errors.push(createError('name', 'the value is empty'))
+  }
+
+  if (!plugin.version) {
+    errors.push(createError('version', 'the value is empty'))
+  }
+
+  if (!plugin.Model || typeof plugin.Model.prototype.getData !== 'function') {
+    errors.push(createError('Model', 'the value is empty or the "getData" function is not added'))
+  }
+
+  if (errors.length === 0) {
+    return { valid: true }
+  } else {
+    return { valid: false, errors }
+  }
+}

--- a/test/utils/validate-plugin/provider.test.js
+++ b/test/utils/validate-plugin/provider.test.js
@@ -1,0 +1,135 @@
+/* eslint-env mocha */
+
+const os = require('os')
+const path = require('path')
+const chai = require('chai')
+const proxyquire = require('proxyquire')
+const createNewProject = require('../../../src/utils/create-new-project')
+
+const modulePath = '../../../src/utils/validate-plugin'
+const validatePropertyPath = '../../../src/utils/validate-plugin/validate-provider'
+const expect = chai.expect
+const temp = os.tmpdir()
+
+const defaultOptions = {
+  skipGit: true,
+  skipInstall: true,
+  quiet: true
+}
+
+let pluginName, pluginPath
+
+function getProvider () {
+  function Model (koop) { }
+  Model.prototype.getData = () => {}
+  return {
+    type: 'provider',
+    name: 'provider-name',
+    version: '1',
+    Model
+  }
+}
+
+describe('utils/validate-plugin', function () {
+  describe('provider', function () {
+    this.timeout(5000)
+
+    beforeEach(async () => {
+      pluginName = `validate-command-test-${Date.now()}`
+      pluginPath = path.join(temp, pluginName)
+      await createNewProject(temp, 'provider', pluginName, defaultOptions)
+    })
+
+    it('should return valid=true for a valid provider', async () => {
+      const validatePlugin = require(modulePath)
+      const result = await validatePlugin(pluginPath)
+      expect(result.valid).to.equal(true)
+      expect(result.errors).to.equal(undefined)
+    })
+
+    it('should return the valid=false and errors if the type property is incorrect', async () => {
+      const provider = getProvider()
+      provider.type = 'not-a-type'
+
+      const validateProvider = proxyquire(validatePropertyPath, {
+        './load-plugin': async () => provider
+      })
+      const validatePlugin = proxyquire(modulePath, {
+        './validate-provider': validateProvider
+      })
+
+      const result = await validatePlugin(pluginPath)
+      expect(result.valid).to.equal(false)
+      expect(result.errors).to.have.lengthOf(1)
+      expect(result.errors[0].property).to.equal('type')
+    })
+
+    it('should return the valid=false and errors if the name property is emtpy', async () => {
+      const provider = getProvider()
+      provider.name = null
+
+      const validateProvider = proxyquire(validatePropertyPath, {
+        './load-plugin': async () => provider
+      })
+      const validatePlugin = proxyquire(modulePath, {
+        './validate-provider': validateProvider
+      })
+
+      const result = await validatePlugin(pluginPath)
+      expect(result.valid).to.equal(false)
+      expect(result.errors).to.have.lengthOf(1)
+      expect(result.errors[0].property).to.equal('name')
+    })
+
+    it('should return the valid=false and errors if the version property is emtpy', async () => {
+      const provider = getProvider()
+      provider.version = null
+
+      const validateProvider = proxyquire(validatePropertyPath, {
+        './load-plugin': async () => provider
+      })
+      const validatePlugin = proxyquire(modulePath, {
+        './validate-provider': validateProvider
+      })
+
+      const result = await validatePlugin(pluginPath)
+      expect(result.valid).to.equal(false)
+      expect(result.errors).to.have.lengthOf(1)
+      expect(result.errors[0].property).to.equal('version')
+    })
+
+    it('should return the valid=false and errors if the Model property is emtpy', async () => {
+      const provider = getProvider()
+      provider.Model = null
+
+      const validateProvider = proxyquire(validatePropertyPath, {
+        './load-plugin': async () => provider
+      })
+      const validatePlugin = proxyquire(modulePath, {
+        './validate-provider': validateProvider
+      })
+
+      const result = await validatePlugin(pluginPath)
+      expect(result.valid).to.equal(false)
+      expect(result.errors).to.have.lengthOf(1)
+      expect(result.errors[0].property).to.equal('Model')
+    })
+
+    it('should return the valid=false and errors if the getData() function is emtpy', async () => {
+      const provider = getProvider()
+      provider.Model.prototype.getData = null
+
+      const validateProvider = proxyquire(validatePropertyPath, {
+        './load-plugin': async () => provider
+      })
+      const validatePlugin = proxyquire(modulePath, {
+        './validate-provider': validateProvider
+      })
+
+      const result = await validatePlugin(pluginPath)
+      expect(result.valid).to.equal(false)
+      expect(result.errors).to.have.lengthOf(1)
+      expect(result.errors[0].property).to.equal('Model')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new `validate` command to check wether the plugin exports follow the Koop specification. It currently only supports the provider type.