### PR TITLE
F/specify deployment target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Plugin list in the `koop.json`
 * New `remove` command and API
 * New `list` command and API
-* New `Validate` command and API
+* New `validate` command and API
+* New `--deployment-target` option for the `new` command
 
 ### Changed
 * Support adding a plugin that already exists locally
 * Use `koop.json` to configure provider properties
 * Use new logger
-* Prefer using the `:id` parameter in the Koop provider requestURL
+* Prefer using the `:id` parameter in the Koop provider request URL
 
 ## 0.6.3 - 2020-08-28
 ### Change

--- a/docs/commands/new.md
+++ b/docs/commands/new.md
@@ -10,6 +10,9 @@ Positionals:
                          [string] [choices: "app", "provider", "auth", "output"]
   name  project name                                                    [string]
 
+App Options:
+  --deployment-target  specify the app deployment target to add addon files
+                                                    [string] [choices: "docker"]
 Options:
   --config        specify the project configuration in JSON             [string]
   --skip-install  skip dependence installation        [boolean] [default: false]
@@ -20,7 +23,14 @@ Options:
 
 For more details on the project templates, please take a look at the Koop [specification](https://koopjs.github.io/docs/usage/koop-core) and [samples](https://github.com/koopjs?utf8=%E2%9C%93&q=sample).
 
-## API
+### Deployment Target
+
+When creating a new Koop app, you can specify the deployment target with the `--deployment-target`. The CLI can setup necessary addon files and changes for the cloud service to deploy. For example, if the deployment target is set to `docker`, a basic `Dockerfile` will be added into the project root directory.
+
+The details of the deployment addons can be found in Koop's deployment guides:
+* [Docker](https://koopjs.github.io/docs/deployment/docker)
+
+## Node.js API
 
 Create a Koop project in the given directory.
 

--- a/src/cli/commands/add.js
+++ b/src/cli/commands/add.js
@@ -1,4 +1,4 @@
-const addPlugin = require('../utils/add-plugin')
+const addPlugin = require('../../utils/add-plugin')
 
 function builder (yargs) {
   yargs

--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -1,6 +1,6 @@
 const Table = require('easy-table')
 const _ = require('lodash')
-const listPlugins = require('../utils/list-plugins')
+const listPlugins = require('../../utils/list-plugins')
 
 function builder (yargs) {
   yargs

--- a/src/cli/commands/new.js
+++ b/src/cli/commands/new.js
@@ -1,4 +1,5 @@
-const createNewProject = require('../utils/create-new-project')
+const createNewProject = require('../../utils/create-new-project')
+const deploymentTargets = require('../../utils/create-new-project/add-deployment-target/targets')
 
 function builder (yargs) {
   yargs
@@ -30,6 +31,12 @@ function builder (yargs) {
       type: 'string',
       default: 'npm',
       choices: ['npm', 'yarn']
+    })
+    .option('deployment-target', {
+      description: 'specify the app deployment target to add addon files',
+      type: 'string',
+      choices: deploymentTargets,
+      group: 'App Options:'
     })
 }
 

--- a/src/cli/commands/remove.js
+++ b/src/cli/commands/remove.js
@@ -1,4 +1,4 @@
-const removePlugin = require('../utils/remove-plugin')
+const removePlugin = require('../../utils/remove-plugin')
 
 function builder (yargs) {
   yargs

--- a/src/cli/commands/serve.js
+++ b/src/cli/commands/serve.js
@@ -1,4 +1,4 @@
-const serve = require('../utils/serve')
+const serve = require('../../utils/serve')
 
 function builder (yargs) {
   yargs

--- a/src/cli/commands/validate.js
+++ b/src/cli/commands/validate.js
@@ -1,6 +1,6 @@
 const Table = require('easy-table')
 const _ = require('lodash')
-const validatePlugin = require('../utils/validate-plugin')
+const validatePlugin = require('../../utils/validate-plugin')
 
 async function handler (argv) {
   const cwd = process.cwd()

--- a/src/cli/middleware/set-logger.js
+++ b/src/cli/middleware/set-logger.js
@@ -1,4 +1,4 @@
-const Logger = require('../logger')
+const Logger = require('../../utils/logger')
 
 module.exports = (argv) => {
   argv.logger = new Logger(argv)

--- a/src/utils/create-new-project/add-deployment-target/docker/Dockerfile
+++ b/src/utils/create-new-project/add-deployment-target/docker/Dockerfile
@@ -1,0 +1,20 @@
+# Based on the latest Node.js LTS version
+FROM node:lts
+
+# Create app directory in docker
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+RUN npm ci --only=production
+
+# Copy app source code
+COPY . .
+
+# Expose the server port. This must be the same as the one in the config (config/default.json)
+EXPOSE 8080
+
+# Start the Koop app
+CMD [ "node", "src/index.js" ]

--- a/src/utils/create-new-project/add-deployment-target/docker/index.js
+++ b/src/utils/create-new-project/add-deployment-target/docker/index.js
@@ -1,0 +1,8 @@
+const path = require('path')
+const fs = require('fs-extra')
+
+module.exports = async (cwd) => {
+  const src = path.join(__dirname, 'Dockerfile')
+  const dest = path.join(cwd, 'Dockerfile')
+  await fs.copyFile(src, dest)
+}

--- a/src/utils/create-new-project/add-deployment-target/index.js
+++ b/src/utils/create-new-project/add-deployment-target/index.js
@@ -1,0 +1,12 @@
+const targets = require('./targets')
+const addDocker = require('./docker')
+
+module.exports = async (cwd, options) => {
+  const target = options.deploymentTarget
+
+  if (!targets.includes(target)) {
+    throw new Error(`Deployment target not supported: ${target}`)
+  } else if (target === 'docker') {
+    return addDocker(cwd)
+  }
+}

--- a/src/utils/create-new-project/add-deployment-target/targets.js
+++ b/src/utils/create-new-project/add-deployment-target/targets.js
@@ -1,0 +1,3 @@
+module.exports = [
+  'docker'
+]

--- a/src/utils/create-new-project/index.js
+++ b/src/utils/create-new-project/index.js
@@ -6,6 +6,7 @@ const { installDependencies } = require('../manage-dependencies')
 const addComponents = require('./add-components')
 const updatePackage = require('./update-package')
 const updateKoopConfig = require('./update-koop-config')
+const addDeploymentTarget = require('./add-deployment-target')
 
 /**
  * Creat a new koop project.
@@ -65,6 +66,11 @@ module.exports = async (cwd, type, name, options = {}) => {
     // install dependencies
     await installDependencies(projectPath, options)
     logger.info('\u2713 installed dependencies')
+  }
+
+  if (options.addDeploymentTarget) {
+    // add deployment target addon files
+    await addDeploymentTarget(projectPath, options)
   }
 
   /**

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,14 @@
+/* eslint-env mocha */
+
+const path = require('path')
+const execa = require('execa')
+const { expect } = require('chai')
+
+describe('src/cli', () => {
+  it('should load and run CLI commands', async () => {
+    const packageInfo = require('../package.json')
+    const cliPath = path.join(__dirname, '..', packageInfo.bin.koop)
+    const { stdout } = await execa('node', [cliPath, '--version'])
+    expect(stdout).to.equal(packageInfo.version)
+  })
+})

--- a/test/utils/create-new-project/add-deployment-target.test.js
+++ b/test/utils/create-new-project/add-deployment-target.test.js
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+
+const os = require('os')
+const path = require('path')
+const chai = require('chai')
+const fs = require('fs-extra')
+const createNewProject = require('../../../src/utils/create-new-project')
+const Logger = require('../../../src/utils/logger')
+
+const modulePath = '../../../src/utils/create-new-project/add-deployment-target'
+const addDeploymentTarget = require(modulePath)
+
+const expect = chai.expect
+const temp = os.tmpdir()
+
+const defaultOptions = {
+  skipGit: true,
+  skipInstall: true,
+  quiet: true,
+  logger: new Logger({ quiet: true })
+}
+
+let appName, appPath
+
+describe('utils/create-new-project/add-deployment-target', function () {
+  this.timeout(5000)
+
+  beforeEach(async () => {
+    appName = `add-deployment-target-test-${Date.now()}`
+    appPath = path.join(temp, appName)
+    await createNewProject(temp, 'app', appName, defaultOptions)
+  })
+
+  it('should throw an error if the deployment target is not recognized', async function () {
+    try {
+      await addDeploymentTarget(appPath, {
+        deploymentTarget: 'no-such-thing'
+      })
+
+      throw new Error('should not pass')
+    } catch (e) {
+      expect(e).to.be.an('Error')
+    }
+  })
+
+  it('should create a Dockerfile for the target "docker"', async function () {
+    await addDeploymentTarget(appPath, {
+      deploymentTarget: 'docker'
+    })
+
+    const expectedFile = path.join(appPath, 'Dockerfile')
+    expect(await fs.pathExists(expectedFile)).to.equal(true)
+  })
+})

--- a/test/utils/create-new-project/index.test.js
+++ b/test/utils/create-new-project/index.test.js
@@ -4,11 +4,14 @@ const chai = require('chai')
 const path = require('path')
 const fs = require('fs-extra')
 const os = require('os')
-const createNewProject = require('../../../src/utils/create-new-project')
+const proxyquire = require('proxyquire')
 const Logger = require('../../../src/utils/logger')
 
 const expect = chai.expect
 const temp = os.tmpdir()
+
+const modulePath = '../../../src/utils/create-new-project'
+const createNewProject = require(modulePath)
 
 const defaultOptions = {
   skipGit: true,
@@ -134,5 +137,23 @@ describe('utils/create-new-project', () => {
     const configPath = path.join(appPath, 'koop.json')
     const config = await fs.readJson(configPath)
     expect(config.npmClient).to.equal('yarn')
+  })
+
+  it('should set the deployment addon files if the deployment targe is specified', async () => {
+    const createMock = proxyquire(modulePath, {
+      './add-deployment-target': (cwd, options) => {
+        expect(options.deploymentTarget).to.equal('docker')
+      }
+    })
+
+    await createMock(
+      temp,
+      'app',
+      appName,
+      {
+        ...defaultOptions,
+        deploymentTarget: 'docker'
+      }
+    )
   })
 })


### PR DESCRIPTION
* Add a `--deployment-target` option for the `new` command. If specified, it can add necessary files and changes for deployment. (#65)
* Fix a bug of loading command modules and add test