### PR TITLE
Updated .gitignore source url

### DIFF
--- a/src/utils/create-new-project/setup-git.js
+++ b/src/utils/create-new-project/setup-git.js
@@ -8,7 +8,7 @@ module.exports = async (cwd) => {
   await execa(scripts.GIT_INIT, { cwd, shell: true })
 
   // add gitignore
-  const res = await fetch('https://rawcdn.githack.com/github/gitignore/master/Node.gitignore')
+  const res = await fetch('https://raw.githubusercontent.com/github/gitignore/master/Node.gitignore')
   const gitignore = await res.text()
 
   return fs.outputFile(path.join(cwd, '.gitignore'), gitignore)


### PR DESCRIPTION
### The issue
Fixed this error with the command `koop new provider`, when fetching the `.gitignore` file:
```
FetchError: request to https://rawcdn.githack.com/github/gitignore/master/Node.gitignore failed, reason: unable to verify the first certificate
    at ClientRequest.<anonymous> ([..]\@koopjs\cli\node_modules\node-fetch\lib\index.js:1491:11)
    at ClientRequest.emit (node:events:390:28)
    at TLSSocket.socketErrorListener (node:_http_client:447:9)
    at TLSSocket.emit (node:events:390:28)
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  type: 'system',
  errno: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
  code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
}
```

It seems that the url changed and due to the redirect the certificate can't be verified.

### The fix
Changed the url to what the old url is redirecting to:
https://raw.githubusercontent.com/github/gitignore/master/Node.gitignore

### Caution: test fails due to other issue
`npm test` fails and throws this error:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module [..]\koop-cli\node_modules\node-fetch\src\index.js from [..]\contribute\koop-cli\src\utils\create-new-project\setup-git.js not supported.
Instead change the require of index.js in C:\Data\Projects\contribute\koop-cli\src\utils\create-new-project\setup-git.js to a dynamic import() which is available in all CommonJS modules.
```

This is because `node-fetch` 3+ no longer uses `require()` syntax. Fixing this would mean everything needs to be changed to `import` syntax. 
